### PR TITLE
Beast encoder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 build
 swig
 .directory
+.DS_Store

--- a/apps/get_correlated_records.py
+++ b/apps/get_correlated_records.py
@@ -18,7 +18,7 @@ bk_station = [37.854246, -122.266701, 100]
 raw_stamps = []
 
 #first iterate through both files to find the estimated time difference. doesn't have to be accurate to more than 1ms or so.
-#to do this, look for type 17 position packets with the same data. assume they're unique. print the tdiff.
+#to do this, look for type 17,18,19 position packets with the same data. assume they're unique. print the tdiff.
 
 #collect a list of raw timestamps for each aircraft from each station
 #the raw stamps have to be processed into corrected stamps OR distance has to be included in each
@@ -68,7 +68,8 @@ for station0_report in records[0]: #iterate over list of reports from station 0
 #print all_heard
 
 #ok, now let's pull out the location-bearing packets so we can find our time offset
-position_reports = [x for x in all_heard if x["data"]["msgtype"] == 17 and 9 <= (x["data"]["longdata"] >> 51) & 0x1F <= 18]
+msgtype = x["data"]["msgtype"]
+position_reports = [x for x in all_heard if msgtype == 17 or msgtype == 18 or msgtype == 19 and 9 <= (x["data"]["longdata"] >> 51) & 0x1F <= 18]
 offset_list = []
 #there's probably a way to list-comprehension-ify this but it looks hard
 for msg in position_reports:

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -27,7 +27,7 @@ add_library(air_modes SHARED
     slicer_impl.cc
     modes_crc.cc
 )
-target_link_libraries(air_modes ${Boost_LIBRARIES} ${GNURADIO_RUNTIME_LIBRARIES})
+target_link_libraries(air_modes ${Boost_LIBRARIES} ${GNURADIO_RUNTIME_LIBRARIES} 1090)
 set_target_properties(air_modes PROPERTIES DEFINE_SYMBOL "AIR_MODES_EXPORTS")
 set_target_properties(air_modes PROPERTIES SOVERSION "${gr-gr-air-modes_VERSION_MAJOR}")
 set_target_properties(air_modes PROPERTIES VERSION "${gr-gr-air-modes_VERSION_MAJOR}.${gr-gr-air-modes_VERSION_MINOR}")

--- a/lib/slicer_impl.cc
+++ b/lib/slicer_impl.cc
@@ -205,7 +205,7 @@ int air_modes::slicer_impl::work(int noutput_items,
 
         // try to decode beast message
         struct modesMessage mm;
-        if (lib1090HandleFrame(&mm, rx_packet.data, pmt::to_uint64(tstamp)) == 0) {
+        if (lib1090HandleFrame(&mm, rx_packet.data, pmt::to_uint64(pmt::tuple_ref(tstamp,0)) == 0) {
 		// TODO want to use the corrected frame?
         }
         d_payload.str("");

--- a/lib/slicer_impl.cc
+++ b/lib/slicer_impl.cc
@@ -63,7 +63,7 @@ air_modes::slicer_impl::slicer_impl(gr::msg_queue::sptr queue) :
     set_output_multiple(d_check_width*2); //how do you specify buffer size for sinks?
 
     lib1090Init(0.0f, 0.0f, 0.0f);
-    lib1090RunThread(NULL);
+    //lib1090RunThread(NULL);
 }
 
 //this slicer is courtesy of Lincoln Labs. supposedly it is more resistant to mode A/C FRUIT.

--- a/python/az_map.py
+++ b/python/az_map.py
@@ -184,6 +184,8 @@ class az_map_output:
         self._cpr = cprdec
         self.model = model
         pub.subscribe("type17_dl", self.output)
+        pub.subscribe("type18_dl", self.output)
+        pub.subscribe("type19_dl", self.output)
 
     def output(self, msg):
         try:

--- a/python/flightgear.py
+++ b/python/flightgear.py
@@ -26,11 +26,13 @@ class output_flightgear:
         self.sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
         self.sock.connect((self.hostname, self.port))
         pub.subscribe("type17_dl", self.output)
+        pub.subscribe("type18_dl", self.output)
+        pub.subscribe("type19_dl", self.output)
 
     def output(self, msg):
         try:
             msgtype = msg.data["df"]
-            if msgtype == 17: #ADS-B report
+            if msgtype == 17 or msgtype == 18 or msgtype == 19: #ADS-B report
                 icao24 = msg.data["aa"]
                 bdsreg = msg.data["me"].get_type()
                 if bdsreg == 0x08: #ident packet

--- a/python/gui_model.py
+++ b/python/gui_model.py
@@ -156,7 +156,7 @@ class dashboard_output:
                 newrow["icao"] = msg.ecc
                 self.model.addRecord(newrow)
             
-            elif msgtype == 17:
+            elif msgtype == 17 or msgtype == 18 or msgtype == 19:
                 icao = msg.data["aa"]
                 newrow["icao"] = icao
                 subtype = msg.data["ftc"]

--- a/python/msprint.py
+++ b/python/msprint.py
@@ -128,7 +128,14 @@ class output_print:
     self._print(retstr)
 
   #the only one which requires state
-  def handle17(self, msg):
+  #17,18,and 19 are all the same!
+  def handle18(self, msg):
+    return self.handle17(msg, 18)
+
+  def handle19(self, msg):
+    return self.handle17(msg, 19)
+
+  def handle17(self, msg, t=17):
     icao24 = msg.data["aa"]
     bdsreg = msg.data["me"].get_type()
 
@@ -136,17 +143,17 @@ class output_print:
     try:
         if bdsreg == 0x08:
           (ident, typestring) = air_modes.parseBDS08(msg.data)
-          retstr += "Type 17 BDS0,8 (ident) from %x type %s ident %s" % (icao24, typestring, ident)
+          retstr += "Type %d BDS0,8 (ident) from %x type %s ident %s" % (t, icao24, typestring, ident)
 
         elif bdsreg == 0x06:
           [ground_track, decoded_lat, decoded_lon, rnge, bearing] = air_modes.parseBDS06(msg.data, self._cpr)
-          retstr += "Type 17 BDS0,6 (surface report) from %x at (%.6f, %.6f) ground track %i" % (icao24, decoded_lat, decoded_lon, ground_track)
+          retstr += "Type %d BDS0,6 (surface report) from %x at (%.6f, %.6f) ground track %i" % (t, icao24, decoded_lat, decoded_lon, ground_track)
           if rnge is not None and bearing is not None:
             retstr += " (%.2f @ %.0f)" % (rnge, bearing)
 
         elif bdsreg == 0x05:
           [altitude, decoded_lat, decoded_lon, rnge, bearing] = air_modes.parseBDS05(msg.data, self._cpr)
-          retstr += "Type 17 BDS0,5 (position report) from %x at (%.6f, %.6f)" % (icao24, decoded_lat, decoded_lon)
+          retstr += "Type %d BDS0,5 (position report) from %x at (%.6f, %.6f)" % (t, icao24, decoded_lat, decoded_lon)
           if rnge is not None and bearing is not None:
             retstr += " (" + "%.2f" % rnge + " @ " + "%.0f" % bearing + ")"
           retstr += " at " + str(altitude) + "ft"
@@ -155,25 +162,25 @@ class output_print:
           subtype = msg.data["bds09"].get_type()
           if subtype == 0:
             [velocity, heading, vert_spd, turnrate] = air_modes.parseBDS09_0(msg.data)
-            retstr += "Type 17 BDS0,9-%i (track report) from %x with velocity %.0fkt heading %.0f VS %.0f turn rate %.0f" \
-                     % (subtype, icao24, velocity, heading, vert_spd, turnrate)
+            retstr += "Type %d BDS0,9-%i (track report) from %x with velocity %.0fkt heading %.0f VS %.0f turn rate %.0f" \
+                     % (t, subtype, icao24, velocity, heading, vert_spd, turnrate)
           elif subtype == 1:
             [velocity, heading, vert_spd] = air_modes.parseBDS09_1(msg.data)
-            retstr += "Type 17 BDS0,9-%i (track report) from %x with velocity %.0fkt heading %.0f VS %.0f" % (subtype, icao24, velocity, heading, vert_spd)
+            retstr += "Type %d BDS0,9-%i (track report) from %x with velocity %.0fkt heading %.0f VS %.0f" % (t, subtype, icao24, velocity, heading, vert_spd)
           elif subtype == 3:
             [mag_hdg, vel_src, vel, vert_spd, geo_diff] = air_modes.parseBDS09_3(msg.data)
-            retstr += "Type 17 BDS0,9-%i (air course report) from %x with %s %.0fkt magnetic heading %.0f VS %.0f geo. diff. from baro. alt. %.0fft" \
-                     % (subtype, icao24, vel_src, vel, mag_hdg, vert_spd, geo_diff)
+            retstr += "Type %d BDS0,9-%i (air course report) from %x with %s %.0fkt magnetic heading %.0f VS %.0f geo. diff. from baro. alt. %.0fft" \
+                     % (t, subtype, icao24, vel_src, vel, mag_hdg, vert_spd, geo_diff)
 
           else:
-            retstr += "Type 17 BDS0,9-%i from %x not implemented" % (subtype, icao24)
+            retstr += "Type %d BDS0,9-%i from %x not implemented" % (t, subtype, icao24)
 
         elif bdsreg == 0x62:
           emerg_str = air_modes.parseBDS62(data)
-          retstr += "Type 17 BDS6,2 (emergency) from %x type %s" % (icao24, emerg_str)
+          retstr += "Type %d BDS6,2 (emergency) from %x type %s" % (t, icao24, emerg_str)
 
         else:
-          retstr += "Type 17 with FTC=%i from %x not implemented" % (msg.data["ftc"], icao24)
+          retstr += "Type %d with FTC=%i from %x not implemented" % (t, msg.data["ftc"], icao24)
     except ADSBError:
         return
 

--- a/python/parse.py
+++ b/python/parse.py
@@ -119,7 +119,7 @@ class bds09_reply(data_field):
   def get_numbits(self):
     return 51
 
-#type 17 extended squitter data
+#type 17,18,19 extended squitter data
 class me_reply(data_field):
   #types in this format are listed by BDS register
   #TODO: add comments explaining these fields
@@ -217,6 +217,8 @@ class modes_reply(data_field):
            11: {"df": (1,5), "ca": (6,3), "aa": (9,24), "pi": (33,24)},
            16: {"df": (1,5), "vs": (6,1), "sl": (9,3), "ri": (14,4), "ac": (20,13), "mv": (33,56), "ap": (88,24)},
            17: {"df": (1,5), "ca": (6,3), "aa": (9,24), "me": (33,56, me_reply), "pi": (88,24)},
+           18: {"df": (1,5), "ca": (6,3), "aa": (9,24), "me": (33,56, me_reply), "pi": (88,24)},
+           19: {"df": (1,5), "ca": (6,3), "aa": (9,24), "me": (33,56, me_reply), "pi": (88,24)},
            20: {"df": (1,5), "fs": (6,3), "dr": (9,5), "um": (14,6), "ac": (20,13), "mb": (33,56, mb_reply), "ap": (88,24)},
            21: {"df": (1,5), "fs": (6,3), "dr": (9,5), "um": (14,6), "id": (20,13), "mb": (33,56, mb_reply), "ap": (88,24)},
            24: {"df": (1,5), "ke": (6,1), "nd": (7,4), "md": (11,80), "ap": (88,24)}

--- a/python/sbs1.py
+++ b/python/sbs1.py
@@ -62,7 +62,7 @@ class output_sbs1:
 
     #it could be cleaner if there were separate output_* fns
     #but this works
-    for i in (0, 4, 5, 11, 17):
+    for i in (0, 4, 5, 11, 17, 18, 19):
         pub.subscribe("type%i_dl" % i, self.output)
 
     #spawn thread to add new connections as they come in
@@ -144,7 +144,7 @@ class output_sbs1:
       outmsg = self.pp5(msg.data, msg.ecc)
     elif msgtype == 11:
       outmsg = self.pp11(msg.data, msg.ecc)
-    elif msgtype == 17:
+    elif msgtype == 17 or msgtype == 18 or msgtype == 19:
       outmsg = self.pp17(msg.data)
     else:
       raise NoHandlerError(msgtype)

--- a/python/sql.py
+++ b/python/sql.py
@@ -64,6 +64,8 @@ class output_sql:
     self._db.close()
     self._db = None
     publisher.subscribe("type17_dl", self.insert)
+    publisher.subscribe("type18_dl", self.insert)
+    publisher.subscribe("type19_dl", self.insert)
 
   def insert(self, message):
     with self._lock:
@@ -90,7 +92,7 @@ class output_sql:
     #this version ignores anything that isn't Type 17 for now, because we just don't care
     query = None
     msgtype = msg.data["df"]
-    if msgtype == 17:
+    if msgtype == 17 or msgtype == 18 or msgtype == 19:
       query = self.sql17(msg.data)
       #self["new_adsb"] = data["aa"] #publish change notification
 


### PR DESCRIPTION
use lib1090 to output beast-format messages to the standard output, hopefully. 

also type 17, 18, and 19 all have the exact same message format. 18 indicates TIS-B, or a non-transponder-based squitter message. 19 indicates a military aircraft squitter message, but they all have the same data. Not sure if government would be happy about us applying MLAT to aircraft such as AF2 which I managed to pick up today while it was clearly deliberately not broadcasting its latitude and longitude. But then, not like it's particularly difficult to triangulate the position of any object that either reflects or transmits RF as long as you have TWO RTL-SDRs, as evidenced by the entirely passive RTL-SDR radars that depend only on strong enough FM radio or VHF/UHF television transmitters.